### PR TITLE
Separated Bot logic and HipChat send/receive logic

### DIFF
--- a/src/AutoBot.Cmd/AutoBot.Cmd.csproj
+++ b/src/AutoBot.Cmd/AutoBot.Cmd.csproj
@@ -64,6 +64,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="HipChat\Session.cs" />
     <Compile Include="Host\AutoBotRawUserInterface.cs" />
     <Compile Include="Host\AutoBotUserInterface.cs" />
     <Compile Include="CommandLine.cs" />

--- a/src/AutoBot.Cmd/HipChat.cs
+++ b/src/AutoBot.Cmd/HipChat.cs
@@ -1,17 +1,10 @@
-﻿using System;
+﻿using jabber;
+using jabber.protocol.client;
+using System;
 using System.Collections;
 using System.Collections.ObjectModel;
 using System.Configuration;
 using System.Management.Automation;
-using System.Net.Security;
-using System.Security.Cryptography.X509Certificates;
-using System.Threading;
-using jabber;
-using jabber.client;
-using jabber.connection;
-using jabber.protocol;
-using jabber.protocol.client;
-using jabber.protocol.iq;
 using log4net;
 using System.Linq;
 
@@ -19,190 +12,32 @@ namespace AutoBot.Cmd
 {
     public static class HipChat
     {
-        private static readonly JabberClient JabberClient;
-        private static readonly PresenceManager PresenceManager;
-        private static readonly PowerShellRunner PowershellRunner;
 
-        private static readonly ManualResetEvent Done;
-        private static readonly DiscoManager DiscoManager;
-        private static readonly ILog Logger;
-        
-        private static readonly string HipChatServer;
-        private static readonly string HipChatUsername;
-        private static readonly string HipChatPassword; 
-        private static readonly string HipChatResource;
-        private static readonly string HipChatBotMentionName;
-        private static readonly string HipChatBotNickName;
-        private static readonly string HipChatRooms;
-        
+        private static readonly AutoBot.HipChat.Session Session = new AutoBot.HipChat.Session();
+        private static readonly PowerShellRunner PowershellRunner;
+        private static readonly ILog Logger = LogManager.GetLogger(typeof(AutoBot.Cmd.Program));
+                
         static HipChat()
         {
-            HipChatServer = ConfigurationManager.AppSettings["HipChatServer"];
-            HipChatUsername = ConfigurationManager.AppSettings["HipChatUsername"];
-            HipChatPassword = ConfigurationManager.AppSettings["HipChatPassword"];
-            HipChatResource = ConfigurationManager.AppSettings["HipChatResource"];
-            HipChatBotMentionName = ConfigurationManager.AppSettings["HipChatBotMentionName"];
-            HipChatBotNickName = ConfigurationManager.AppSettings["HipChatBotNickName"];
-            HipChatRooms = ConfigurationManager.AppSettings["HipChatRooms"];
-
-            PresenceManager = new PresenceManager
-                                   {
-                                       Stream = JabberClient
-                                   };
             
-            PowershellRunner = new PowerShellRunner();
-            Done = new ManualResetEvent(false);
-            DiscoManager = new DiscoManager();
-            Logger = LogManager.GetLogger(typeof(Program));
-            
-            JabberClient = new JabberClient
-                                {
-                                    Server = HipChatServer,
-                                    User = HipChatUsername,
-                                    Password = HipChatPassword,
-                                    Resource = HipChatResource,
-                                    AutoStartTLS = true,
-                                    PlaintextAuth = true,
-                                    AutoPresence = true,
-                                    AutoRoster = false,
-                                    AutoReconnect = -1,
-                                    AutoLogin = true
-                                };
-
-            PresenceManager.OnPrimarySessionChange += _presenceManager_OnPrimarySessionChange;
-
-            JabberClient.OnConnect += jabber_OnConnect;
-            JabberClient.OnAuthenticate += jabber_OnAuthenticate;
-            JabberClient.OnInvalidCertificate += jabber_OnInvalidCertificate;
-            JabberClient.OnError += jabber_OnError;
-            JabberClient.OnReadText += jabber_OnReadText;
-            JabberClient.OnWriteText += jabber_OnWriteText;
-            JabberClient.OnStreamInit += jabber_OnStreamInit;
-            JabberClient.OnDisconnect += jabber_OnDisconnect;
-            JabberClient.OnRegistered += jabber_OnRegistered;
-            JabberClient.OnRegisterInfo += jabber_OnRegisterInfo;
-            JabberClient.OnMessage += jabber_OnMessage;
-
-        }
-
-        private static void jabber_OnMessage(object sender, Message msg)
-        {
-            Logger.Debug(string.Format("RECV From: {0}@{1} : {2}", msg.From.User, msg.From.Server, msg.Body));
-            ProcessRequest(msg);
-        }
-
-        private static bool jabber_OnRegisterInfo(object sender, Register register)
-        {
-            return true;
-        }
-
-        private static void jabber_OnRegistered(object sender, IQ iq)
-        {
-            JabberClient.Login();
-        }
-
-        private static void _presenceManager_OnPrimarySessionChange(object sender, JID bare)
-        {
-            if (bare.Bare.Equals(JabberClient.JID.Bare, StringComparison.InvariantCultureIgnoreCase))
-                return;
+            Session.Server = ConfigurationManager.AppSettings["HipChatServer"];
+            Session.UserName = ConfigurationManager.AppSettings["HipChatUsername"];
+            Session.Password = ConfigurationManager.AppSettings["HipChatPassword"];
+            Session.Resource = ConfigurationManager.AppSettings["HipChatResource"];
+            Session.MentionName = ConfigurationManager.AppSettings["HipChatBotMentionName"];
+            Session.NickName = ConfigurationManager.AppSettings["HipChatBotNickName"];
+            Session.SubscribedRooms = ConfigurationManager.AppSettings["HipChatRooms"];
+            Session.OnMessageReceived += Session_OnMessageReceived;
+                       
+            PowershellRunner = new PowerShellRunner();            
         }
 
         public static void SetupChatConnection()
         {
-            // connect. this is synchronous so we'll use a manual reset event
-            // to pause this thread forever. client events will continue to
-            // fire but we won't have to worry about setting up an idle "while" loop.
-            JabberClient.Connect();
-            Done.WaitOne();
+            Session.Connect();
         }
 
-        private static void jabber_OnDisconnect(object sender)
-        {
-            throw new NotImplementedException();
-
-        }
-
-        private static void jabber_OnStreamInit(object o, ElementStream elementStream)
-        {
-            var client = (JabberClient)o;
-            DiscoManager.Stream = client;
-             
-        }
-
-        private static void jabber_OnConnect(object o, StanzaStream s)
-        {
-            Logger.Info("Connecting");
-            var client = (JabberClient) o;
-        }
-
-        private static void hlp_DiscoHandler_FindServiceWithFeature(DiscoManager sender, DiscoNode node, object state)
-        {
-            if (node == null)
-                return;
-             
-            if (node.Name == "Rooms")
-                DiscoManager.BeginGetItems(node, hlp_DiscoHandler_SubscribeToRooms, new object());
-        }
-
-        private static void hlp_DiscoHandler_SubscribeToRooms(DiscoManager sender, DiscoNode node, object state)
-        {
-            if (node == null)
-                return;
-            if (node.Children != null && HipChatRooms == "@all")
-            {
-                foreach (DiscoNode dn in node.Children)
-                {
-                    Logger.Info(string.Format("Subscribing to: {0}:{1}", dn.JID, dn.Name));
-                    // we have to build a new JID here, with the nickname included http://xmpp.org/extensions/xep-0045.html#enter-muc
-                    JID subscriptionJid = new JID(dn.JID.User, dn.JID.Server, "AutoBot .");
-                    JabberClient.Subscribe(subscriptionJid, HipChatBotNickName, null);
-                }
-            }
-        }
-
-        private static void jabber_OnAuthenticate(object o)
-        {
-            Logger.Info("Authenticated");
-            DiscoManager.BeginFindServiceWithFeature(URI.MUC, hlp_DiscoHandler_FindServiceWithFeature, new object());
-        }
-
-        private static bool jabber_OnInvalidCertificate(object o, X509Certificate cert, X509Chain chain, SslPolicyErrors errors)
-        {
-            // the current jabber server has an invalid certificate,
-            // but override validation and accept it anyway.
-            Logger.Info("Validating certificate");
-            return true;
-        }
-
-        private static void jabber_OnError(object o, Exception ex)
-        {
-            Logger.Error("ERROR!:", ex);
-            throw ex;
-        }
-
-        private static void jabber_OnReadText(object sender, string text)
-        {
-            // ignore keep-alive spaces
-            if (text == " ")
-            {
-                Logger.Debug("RECV: Keep alive");
-                return;
-            }
-            Logger.Debug(string.Format("RECV: {0}", text));
-        }
-
-        private static void jabber_OnWriteText(object sender, string text)
-        {
-            // ignore keep-alive spaces
-            if (text == " ")
-            {
-                Logger.Debug("RECV: Keep alive");
-                return;
-            }
-            Logger.Debug(string.Format("SEND: {0}", text));
-        }
-
-        private static void ProcessRequest(Message message)
+        private static void Session_OnMessageReceived(object sender, Message message)
         {
             if (message.Body == null && message.X == null)
                 return;
@@ -215,7 +50,7 @@ namespace AutoBot.Cmd
             JID responseJid = new JID(message.From.User, message.From.Server, message.From.Resource);
             
             // intercept a handful of messages not directly for AutoBot
-            if (message.Type == MessageType.groupchat && !chatText.Trim().StartsWith(HipChatBotMentionName))
+            if (message.Type == MessageType.groupchat && !chatText.Trim().StartsWith(Session.MentionName))
             {
                 chatText = RemoveMentionFromMessage(chatText);
                 SendRandomResponse(responseJid, chatText, message.Type);
@@ -233,7 +68,7 @@ namespace AutoBot.Cmd
         private static string RemoveMentionFromMessage(string chatText)
         {
             //TODO: Remove all @'s
-            return chatText.Replace(HipChatBotMentionName, string.Empty).Trim();
+            return chatText.Replace(Session.MentionName, string.Empty).Trim();
         }
 
         private static PowerShellCommand BuildPowerShellCommand(string chatText)
@@ -269,7 +104,7 @@ namespace AutoBot.Cmd
                         message += string.Format("{0} = {1}\n", dictionaryEntry.Key, dictionaryEntry.Value);
                 }
                 
-                JabberClient.Message(messageType, replyTo, message);
+                Session.SendMessage(messageType, replyTo, message);
             }
         }
 

--- a/src/AutoBot.Cmd/HipChat/Session.cs
+++ b/src/AutoBot.Cmd/HipChat/Session.cs
@@ -1,0 +1,264 @@
+﻿using jabber;
+using jabber.client;
+using jabber.connection;
+using jabber.protocol;
+using jabber.protocol.client;
+using jabber.protocol.iq;
+using log4net;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading;
+
+namespace AutoBot.HipChat
+{
+    
+    internal class Session
+    {
+
+        #region Events
+
+        public delegate void MessageReceivedHandler(object sender, Message msg);
+        public event MessageReceivedHandler OnMessageReceived;
+
+        #endregion
+
+        #region Fields
+
+        private JabberClient m_JabberClient;
+        private DiscoManager m_DiscoManager;
+        private PresenceManager m_PresenceManager;
+
+        private readonly ILog m_Logger = LogManager.GetLogger(typeof(AutoBot.Cmd.Program));
+        private ManualResetEvent m_Waiter;
+
+        #endregion
+
+        #region Constructors
+
+        public Session()
+            : base()
+        {
+        }
+        
+        #endregion
+
+        #region Properties
+
+        public string Server
+        {
+            get;
+            set;
+        }
+
+        public string UserName
+        {
+            get;
+            set;
+        }
+
+        public string Password
+        {
+            get;
+            set;
+        }
+
+        public string Resource
+        {
+            get;
+            set;
+        }
+
+        public string MentionName
+        {
+            get;
+            set;
+        }
+
+        public string NickName
+        {
+            get;
+            set;
+        }
+
+        public string SubscribedRooms
+        {
+            get;
+            set;
+        }
+
+        #endregion
+
+        #region JabberClient Event Handlers
+
+        private void jabber_OnMessage(object sender, Message msg)
+        {
+            m_Logger.Debug(string.Format("RECV From: {0}@{1} : {2}", msg.From.User, msg.From.Server, msg.Body));
+            this.OnMessageReceived(this, msg);
+        }
+
+        private bool jabber_OnRegisterInfo(object sender, Register register)
+        {
+            return true;
+        }
+
+        private void jabber_OnRegistered(object sender, IQ iq)
+        {
+            m_JabberClient.Login();
+        }
+
+        private static void jabber_OnDisconnect(object sender)
+        {
+            throw new NotImplementedException();
+
+        }
+
+        private void jabber_OnStreamInit(object o, ElementStream elementStream)
+        {
+            var client = (JabberClient)o;
+            m_DiscoManager.Stream = client;
+        }
+
+        private void jabber_OnConnect(object o, StanzaStream s)
+        {
+            m_Logger.Info("Connecting");
+            var client = (JabberClient)o;
+        }
+
+        private void jabber_OnAuthenticate(object o)
+        {
+            m_Logger.Info("Authenticated");
+            m_DiscoManager.BeginFindServiceWithFeature(URI.MUC, hlp_DiscoHandler_FindServiceWithFeature, new object());
+        }
+
+        private bool jabber_OnInvalidCertificate(object o, X509Certificate cert, X509Chain chain, SslPolicyErrors errors)
+        {
+            // the current jabber server has an invalid certificate,
+            // but override validation and accept it anyway.
+            m_Logger.Info("Validating certificate");
+            return true;
+        }
+
+        private void jabber_OnError(object o, Exception ex)
+        {
+            m_Logger.Error("ERROR!:", ex);
+            throw ex;
+        }
+
+        private void jabber_OnReadText(object sender, string text)
+        {
+            // ignore keep-alive spaces
+            if (text == " ")
+            {
+                m_Logger.Debug("RECV: Keep alive");
+                return;
+            }
+            m_Logger.Debug(string.Format("RECV: {0}", text));
+        }
+
+        private void jabber_OnWriteText(object sender, string text)
+        {
+            // ignore keep-alive spaces
+            if (text == " ")
+            {
+                m_Logger.Debug("RECV: Keep alive");
+                return;
+            }
+            m_Logger.Debug(string.Format("SEND: {0}", text));
+        }
+
+        #endregion
+
+        #region DiscoHandler Event Handlers 
+
+        private void hlp_DiscoHandler_FindServiceWithFeature(DiscoManager sender, DiscoNode node, object state)
+        {
+            if (node == null)
+                return;
+            if (node.Name == "Rooms")
+                m_DiscoManager.BeginGetItems(node, hlp_DiscoHandler_SubscribeToRooms, new object());
+        }
+
+        private void hlp_DiscoHandler_SubscribeToRooms(DiscoManager sender, DiscoNode node, object state)
+        {
+            if (node == null)
+                return;
+            if (node.Children != null && this.SubscribedRooms == "@all")
+            {
+                foreach (DiscoNode dn in node.Children)
+                {
+                    m_Logger.Info(string.Format("Subscribing to: {0}:{1}", dn.JID, dn.Name));
+                    // we have to build a new JID here, with the nickname included http://xmpp.org/extensions/xep-0045.html#enter-muc
+                    JID subscriptionJid = new JID(dn.JID.User, dn.JID.Server, "AutoBot .");
+                    m_JabberClient.Subscribe(subscriptionJid, this.NickName, null);
+                }
+            }
+        }
+
+        #endregion
+
+        #region PresenceManager Event Handlers
+
+        private  void presenceManager_OnPrimarySessionChange(object sender, JID bare)
+        {
+            if (bare.Bare.Equals(m_JabberClient.JID.Bare, StringComparison.InvariantCultureIgnoreCase))
+                return;
+        }
+
+        #endregion
+
+        #region Methods
+
+        public void Connect()
+        {
+            m_JabberClient = new JabberClient
+            {
+                Server = this.Server,
+                User = this.UserName,
+                Password = this.Password,
+                Resource = this.Resource,
+                AutoStartTLS = true,
+                PlaintextAuth = true,
+                AutoPresence = true,
+                AutoRoster = false,
+                AutoReconnect = -1,
+                AutoLogin = true
+            };
+            m_PresenceManager = new PresenceManager
+            {
+                Stream = m_JabberClient
+            };
+            m_DiscoManager = new DiscoManager();
+            m_Waiter = new ManualResetEvent(false);
+            m_PresenceManager.OnPrimarySessionChange += presenceManager_OnPrimarySessionChange;
+            m_JabberClient.OnConnect += jabber_OnConnect;
+            m_JabberClient.OnAuthenticate += jabber_OnAuthenticate;
+            m_JabberClient.OnInvalidCertificate += jabber_OnInvalidCertificate;
+            m_JabberClient.OnError += jabber_OnError;
+            m_JabberClient.OnReadText += jabber_OnReadText;
+            m_JabberClient.OnWriteText += jabber_OnWriteText;
+            m_JabberClient.OnStreamInit += jabber_OnStreamInit;
+            m_JabberClient.OnDisconnect += jabber_OnDisconnect;
+            m_JabberClient.OnRegistered += jabber_OnRegistered;
+            m_JabberClient.OnRegisterInfo += jabber_OnRegisterInfo;
+            m_JabberClient.OnMessage += jabber_OnMessage;
+            // connect. this is synchronous so we'll use a manual reset event
+            // to pause this thread forever. client events will continue to
+            // fire but we won't have to worry about setting up an idle "while" loop.
+            m_JabberClient.Connect();
+            m_Waiter.WaitOne();
+        }
+
+        public void SendMessage(MessageType messageType, string replyTo, string message)
+        {
+            m_JabberClient.Message(messageType, replyTo, message);
+        }
+
+        #endregion
+
+    }
+
+}


### PR DESCRIPTION
Created an AutoBot.HipChat.Session class to handle the logon, listening and sending. The original AutoBot.HipChat class still handles the bot logic and PowerShell invocation, but the jabber / DiscoManager nonsense is abstracted away into the Session.

All you need to do now from the bot is Session.Connect with the appropriate username / password, then subscribe to the Session.OnMessageReceived event. To send messages, use Session.SendMessage with the same parameters as before.
